### PR TITLE
Allow CSS selectors in main find() method

### DIFF
--- a/src/Traversal.js
+++ b/src/Traversal.js
@@ -36,22 +36,14 @@ export default class Traversal {
 
   find(nodeType: string | Function | Object): NodeArray {
     /**
-     * We support four potential scenarios for matching nodes:
-     * 
-     * 1. a string attempting to match a host node ('host')
-     * 2. a string attempting to match a composite node ('Foo')
-     * 3. a function attempting to match a composite node (Foo)
-     * 
-     * This flag tells us whether we should coerce node.type to a string
-     * so that case 2 works.
+     * If the nodeType is a string we just treat it as a CSS
+     * selector. Since even simple finds like find('li') can
+     * be treated as a CSS selector this makes it so we dont
+     * have to actually check if its a CSS selector or not.
      */
-    const coerceCompositeTypeToString = isString(nodeType)
-    return this.findWhere(type => {
-      if (coerceCompositeTypeToString) {
-        type = getTypeName(type)
-      }
-      return type === nodeType
-    })
+    return isString(nodeType)
+      ? this.findBySelector(nodeType)
+      : this.findWhere(type => type === nodeType)
   }
 
   // @TODO: type this

--- a/src/selector-parser.js
+++ b/src/selector-parser.js
@@ -6,6 +6,7 @@ import {
   hasClass,
   isString,
   isHostOrComposite,
+  getTypeName,
 } from './utilities'
 import prettyFormat from 'pretty-format'
 import NodeArray from './NodeArray'
@@ -53,7 +54,7 @@ function nodeMatchesToken(node: ReactTreeNode, token) {
      * @example 'div' matches <div />
      */
     case TYPE_SELECTOR:
-      return node.type === token.name
+      return getTypeName(node.type) === token.name
     /**
      * Match against the className prop
      * @example '.active' matches <div className='active' />


### PR DESCRIPTION
findBySelector is still available in the public API (for now), but it's verbose and most people probably just want find() to be polymorphic and support whatever they throw into it